### PR TITLE
Implement GPU radix sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ This project is dual-licensed under MIT OR Apache-2.0.
 
 ### Future Improvements
 
-- [ ] GPU-based radix sort (currently using CPU sort)
+- [x] GPU-based radix sort (replaces CPU sort)
 - [ ] Variable K support (currently fixed at k=3)
 - [ ] Half-precision float support
 - [ ] WebGPU browser demo

--- a/src/knn.rs
+++ b/src/knn.rs
@@ -34,6 +34,8 @@ struct ComputePipelines {
     morton: wgpu::ComputePipeline,
     box_bbox: wgpu::ComputePipeline,
     knn: wgpu::ComputePipeline,
+    radix_count: wgpu::ComputePipeline,
+    radix_reorder: wgpu::ComputePipeline,
 }
 
 impl KnnCompute {
@@ -180,12 +182,14 @@ impl KnnCompute {
             mapped_at_creation: false,
         });
         
-        // Indices buffer
-        let indices_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+        // Indices buffer initialized with 0..num_points
+        let indices_data: Vec<u32> = (0..num_points).collect();
+        let indices_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Indices Buffer"),
-            size: (num_points * 4) as u64,
-            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
-            mapped_at_creation: false,
+            contents: cast_slice(&indices_data),
+            usage: wgpu::BufferUsages::STORAGE
+                | wgpu::BufferUsages::COPY_DST
+                | wgpu::BufferUsages::COPY_SRC,
         });
         
         let box_bboxes = device.create_buffer(&wgpu::BufferDescriptor {
@@ -367,62 +371,106 @@ impl KnnCompute {
         Ok(())
     }
     
-    /// Sorts points by Morton code (CPU implementation for now).
+    /// Sorts points by Morton code using a GPU radix sort.
     async fn sort_by_morton(
         &self,
         buffers: &ComputeBuffers,
         num_points: u32,
     ) -> Result<wgpu::Buffer> {
-        debug!("Sorting by Morton code");
-        
-        // Read Morton codes from GPU
-        let morton_staging = self.context.device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("Morton Staging Buffer"),
+        debug!("Sorting by Morton code (GPU radix sort)");
+
+        let device = &self.context.device;
+        let temp_indices = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Temp Indices"),
             size: (num_points * 4) as u64,
-            usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
-        
-        let mut encoder = self.context.device.create_command_encoder(
-            &wgpu::CommandEncoderDescriptor::default()
-        );
-        encoder.copy_buffer_to_buffer(
-            &buffers.morton,
-            0,
-            &morton_staging,
-            0,
-            (num_points * 4) as u64,
-        );
-        self.context.queue.submit(Some(encoder.finish()));
-        
-        // Map and read Morton codes
-        let morton_slice = morton_staging.slice(..);
-        let (tx, rx) = futures::channel::oneshot::channel();
-        morton_slice.map_async(wgpu::MapMode::Read, move |result| {
-            tx.send(result).unwrap();
+        let temp_morton = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Temp Morton"),
+            size: (num_points * 4) as u64,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
         });
-        self.context.device.poll(wgpu::PollType::Wait).map_err(|_| KnnError::ComputeError("Failed to poll device".to_string()))?;
-        rx.await.unwrap().map_err(|e| KnnError::BufferMapError(e))?;
-        
-        let morton_data = morton_slice.get_mapped_range();
-        let morton_codes: Vec<u32> = cast_slice(&morton_data).to_vec();
-        drop(morton_data);
-        morton_staging.unmap();
-        
-        // Create indices and sort
-        let mut indices: Vec<u32> = (0..num_points).collect();
-        indices.sort_unstable_by_key(|&i| morton_codes[i as usize]);
-        
-        // Upload sorted indices
-        let sorted_indices_buffer = self.context.device.create_buffer_init(
-            &wgpu::util::BufferInitDescriptor {
-                label: Some("Sorted Indices Buffer"),
-                contents: cast_slice(&indices),
-                usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+        let prefix = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Radix Prefix"),
+            size: (num_points * 4) as u64,
+            usage: wgpu::BufferUsages::STORAGE,
+            mapped_at_creation: false,
+        });
+        let counts = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Radix Counts"),
+            size: 8,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::COPY_SRC,
+            mapped_at_creation: false,
+        });
+        let params = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Radix Params"),
+            size: 256,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        let workgroups = (num_points + 255) / 256;
+        let mut src_keys = &buffers.morton;
+        let mut dst_keys = &temp_morton;
+        let mut src_indices = &buffers.indices;
+        let mut dst_indices = &temp_indices;
+
+        for bit in 0..30u32 {
+            self.context.queue.write_buffer(&counts, 0, bytemuck::bytes_of(&[0u32, 0u32]));
+            self.context.queue.write_buffer(&params, 0, bytemuck::bytes_of(&[num_points, bit]));
+
+            let bg1 = device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("Radix Count BG"),
+                layout: &self.pipelines.radix_count.get_bind_group_layout(0),
+                entries: &[
+                    wgpu::BindGroupEntry { binding: 0, resource: src_keys.as_entire_binding() },
+                    wgpu::BindGroupEntry { binding: 1, resource: src_indices.as_entire_binding() },
+                    wgpu::BindGroupEntry { binding: 2, resource: prefix.as_entire_binding() },
+                    wgpu::BindGroupEntry { binding: 3, resource: counts.as_entire_binding() },
+                    wgpu::BindGroupEntry { binding: 4, resource: params.as_entire_binding() },
+                ],
+            });
+
+            let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+            {
+                let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor { label: Some("Radix Count Pass"), timestamp_writes: None });
+                pass.set_pipeline(&self.pipelines.radix_count);
+                pass.set_bind_group(0, &bg1, &[]);
+                pass.dispatch_workgroups(workgroups, 1, 1);
             }
-        );
-        
-        Ok(sorted_indices_buffer)
+            self.context.queue.submit(Some(encoder.finish()));
+
+            self.context.queue.write_buffer(&params, 0, bytemuck::bytes_of(&[num_points, bit]));
+            let bg2 = device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("Radix Reorder BG"),
+                layout: &self.pipelines.radix_reorder.get_bind_group_layout(0),
+                entries: &[
+                    wgpu::BindGroupEntry { binding: 0, resource: src_keys.as_entire_binding() },
+                    wgpu::BindGroupEntry { binding: 1, resource: src_indices.as_entire_binding() },
+                    wgpu::BindGroupEntry { binding: 2, resource: prefix.as_entire_binding() },
+                    wgpu::BindGroupEntry { binding: 3, resource: counts.as_entire_binding() },
+                    wgpu::BindGroupEntry { binding: 4, resource: dst_keys.as_entire_binding() },
+                    wgpu::BindGroupEntry { binding: 5, resource: dst_indices.as_entire_binding() },
+                    wgpu::BindGroupEntry { binding: 6, resource: params.as_entire_binding() },
+                ],
+            });
+
+            let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+            {
+                let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor { label: Some("Radix Reorder Pass"), timestamp_writes: None });
+                pass.set_pipeline(&self.pipelines.radix_reorder);
+                pass.set_bind_group(0, &bg2, &[]);
+                pass.dispatch_workgroups(workgroups, 1, 1);
+            }
+            self.context.queue.submit(Some(encoder.finish()));
+
+            std::mem::swap(&mut src_keys, &mut dst_keys);
+            std::mem::swap(&mut src_indices, &mut dst_indices);
+        }
+
+        Ok(src_indices.clone())
     }
     
     /// Computes bounding boxes for each spatial partition box.
@@ -630,6 +678,24 @@ fn create_pipelines(
         compilation_options: Default::default(),
         cache: None,
     });
+
+    let radix_count = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+        label: Some("Radix Count Pipeline"),
+        layout: None,
+        module: &shaders.radix,
+        entry_point: Some("radix_count"),
+        compilation_options: Default::default(),
+        cache: None,
+    });
+
+    let radix_reorder = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+        label: Some("Radix Reorder Pipeline"),
+        layout: None,
+        module: &shaders.radix,
+        entry_point: Some("radix_reorder"),
+        compilation_options: Default::default(),
+        cache: None,
+    });
     
     Ok(ComputePipelines {
         bbox_compute,
@@ -637,6 +703,8 @@ fn create_pipelines(
         morton,
         box_bbox,
         knn,
+        radix_count,
+        radix_reorder,
     })
 }
 

--- a/src/shaders.rs
+++ b/src/shaders.rs
@@ -16,6 +16,8 @@ pub struct ShaderSources {
     pub box_bbox: &'static str,
     /// KNN search shader
     pub knn: &'static str,
+    /// Radix sort shader
+    pub radix: &'static str,
 }
 
 impl Default for ShaderSources {
@@ -25,6 +27,7 @@ impl Default for ShaderSources {
             morton: include_str!("shaders/morton.wgsl"),
             box_bbox: include_str!("shaders/box_bbox.wgsl"),
             knn: include_str!("shaders/knn.wgsl"),
+            radix: include_str!("shaders/sort.wgsl"),
         }
     }
 }
@@ -39,6 +42,8 @@ pub struct CompiledShaders {
     pub box_bbox: wgpu::ShaderModule,
     /// KNN search shader module
     pub knn: wgpu::ShaderModule,
+    /// Radix sort shader module
+    pub radix: wgpu::ShaderModule,
 }
 
 impl CompiledShaders {
@@ -51,12 +56,14 @@ impl CompiledShaders {
         let morton = compile_shader(device, "morton", sources.morton)?;
         let box_bbox = compile_shader(device, "box_bbox", sources.box_bbox)?;
         let knn = compile_shader(device, "knn", sources.knn)?;
+        let radix = compile_shader(device, "radix", sources.radix)?;
         
         Ok(Self {
             bbox,
             morton,
             box_bbox,
             knn,
+            radix,
         })
     }
 }
@@ -101,6 +108,7 @@ mod tests {
         assert!(!sources.morton.is_empty());
         assert!(!sources.box_bbox.is_empty());
         assert!(!sources.knn.is_empty());
+        assert!(!sources.radix.is_empty());
         
         // Verify entry points exist
         assert!(validate_shader_entry_points(
@@ -122,5 +130,10 @@ mod tests {
             sources.knn,
             &["compute_knn"]
         ).is_ok());
+
+        assert!(validate_shader_entry_points(
+            sources.radix,
+            &["radix_count", "radix_reorder"]
+        ).is_ok());
     }
-} 
+}

--- a/src/shaders/sort.wgsl
+++ b/src/shaders/sort.wgsl
@@ -1,0 +1,70 @@
+// Radix Sort Shader
+//
+// Implements a simple GPU radix sort for 32-bit keys.
+// The algorithm performs one pass per bit using atomic counters
+// and two compute stages (count and reorder).
+
+struct Params {
+    num: u32;
+    bit: u32;
+};
+
+@group(0) @binding(0)
+var<storage, read> in_keys: array<u32>;
+@group(0) @binding(1)
+var<storage, read> in_indices: array<u32>;
+@group(0) @binding(2)
+var<storage, read_write> prefix: array<u32>;
+@group(0) @binding(3)
+var<storage, read_write> counts: array<atomic<u32>, 2>;
+@group(0) @binding(4)
+var<uniform> params: Params;
+
+@compute @workgroup_size(256)
+fn radix_count(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let idx = gid.x;
+    if (idx >= params.num) { return; }
+
+    let key = in_keys[idx];
+    let bit = (key >> params.bit) & 1u;
+
+    if (bit == 0u) {
+        prefix[idx] = atomicAdd(&counts[0], 1u);
+    } else {
+        prefix[idx] = atomicAdd(&counts[1], 1u);
+    }
+}
+
+@group(0) @binding(0)
+var<storage, read> r_in_keys: array<u32>;
+@group(0) @binding(1)
+var<storage, read> r_in_indices: array<u32>;
+@group(0) @binding(2)
+var<storage, read> r_prefix: array<u32>;
+@group(0) @binding(3)
+var<storage, read> r_counts: array<atomic<u32>, 2>;
+@group(0) @binding(4)
+var<storage, read_write> out_keys: array<u32>;
+@group(0) @binding(5)
+var<storage, read_write> out_indices: array<u32>;
+@group(0) @binding(6)
+var<uniform> r_params: Params;
+
+@compute @workgroup_size(256)
+fn radix_reorder(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let idx = gid.x;
+    if (idx >= r_params.num) { return; }
+
+    let key = r_in_keys[idx];
+    let bit = (key >> r_params.bit) & 1u;
+    let p = r_prefix[idx];
+    let zeros = atomicLoad(&r_counts[0]);
+
+    var dst = p;
+    if (bit == 1u) {
+        dst = zeros + p;
+    }
+
+    out_keys[dst] = key;
+    out_indices[dst] = r_in_indices[idx];
+}


### PR DESCRIPTION
## Summary
- add GPU radix sort shader and pipelines
- initialize indices buffer on creation
- replace CPU sort with GPU implementation
- track new shader in shader manager
- document feature in README

## Testing
- `cargo test` *(fails: unable to fetch crates)*

------
https://chatgpt.com/codex/tasks/task_e_6889017b04808326b88d26c770e46b24