### PR TITLE
Add SIMD CPU fallback

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,9 @@ authors = ["Your Name <your.email@example.com>"]
 description = "High-performance k-nearest neighbor search using wgpu compute shaders"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/yourusername/simple-knn-wgpu"
+[lib]
+crate-type = ["rlib", "cdylib"]
+
 readme = "README.md"
 keywords = ["knn", "gpu", "wgpu", "compute", "nearest-neighbor"]
 categories = ["algorithms", "science", "graphics"]
@@ -21,6 +24,7 @@ futures = "0.3"
 # Math utilities
 glam = "0.29"
 bytemuck = { version = "1.19", features = ["derive"] }
+rayon = "1.10"
 
 # Error handling
 thiserror = "2.0"

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1,0 +1,201 @@
+use crate::{
+    error::{KnnError, Result, ValidationError},
+    types::{KnnResult, Point3},
+};
+use rayon::prelude::*;
+
+/// CPU fallback implementation using SIMD and rayon parallelism.
+pub fn compute_knn_cpu(points: &[f32]) -> Result<KnnResult> {
+    validate_points(points)?;
+    let start = std::time::Instant::now();
+    let n = points.len() / 3;
+    let mut xs = vec![0.0f32; n];
+    let mut ys = vec![0.0f32; n];
+    let mut zs = vec![0.0f32; n];
+    for i in 0..n {
+        xs[i] = points[i * 3];
+        ys[i] = points[i * 3 + 1];
+        zs[i] = points[i * 3 + 2];
+    }
+    let distances: Vec<f32> = (0..n)
+        .into_par_iter()
+        .map(|i| unsafe { knn_point_simd(i, &xs, &ys, &zs) })
+        .collect();
+    let ms = start.elapsed().as_secs_f32() * 1000.0;
+    Ok(KnnResult {
+        distances,
+        compute_time_ms: Some(ms),
+    })
+}
+
+fn validate_points(points: &[f32]) -> Result<()> {
+    if points.is_empty() {
+        return Err(KnnError::InvalidInput(
+            ValidationError::EmptyArray.to_string(),
+        ));
+    }
+    if points.len() % 3 != 0 {
+        return Err(KnnError::InvalidInput(
+            ValidationError::InvalidShape(points.len() / 3, points.len() % 3).to_string(),
+        ));
+    }
+    for (idx, chunk) in points.chunks_exact(3).enumerate() {
+        let p = Point3::new(chunk[0], chunk[1], chunk[2]);
+        if !p.is_finite() {
+            return Err(KnnError::InvalidInput(
+                ValidationError::InvalidValues(idx).to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[inline]
+unsafe fn knn_point_simd(i: usize, xs: &[f32], ys: &[f32], zs: &[f32]) -> f32 {
+    let xi = xs[i];
+    let yi = ys[i];
+    let zi = zs[i];
+
+    let mut best = [f32::INFINITY; 3];
+
+    #[cfg(target_arch = "x86_64")]
+    {
+        use core::arch::x86_64::*;
+        let xi_v = _mm_set1_ps(xi);
+        let yi_v = _mm_set1_ps(yi);
+        let zi_v = _mm_set1_ps(zi);
+        let mut j = 0;
+        while j + 4 <= xs.len() {
+            let xj = _mm_loadu_ps(xs.as_ptr().add(j));
+            let yj = _mm_loadu_ps(ys.as_ptr().add(j));
+            let zjv = _mm_loadu_ps(zs.as_ptr().add(j));
+            let dx = _mm_sub_ps(xj, xi_v);
+            let dy = _mm_sub_ps(yj, yi_v);
+            let dz = _mm_sub_ps(zjv, zi_v);
+            let mut dist = _mm_mul_ps(dx, dx);
+            dist = _mm_add_ps(dist, _mm_mul_ps(dy, dy));
+            dist = _mm_add_ps(dist, _mm_mul_ps(dz, dz));
+            let mut out = [0f32; 4];
+            _mm_storeu_ps(out.as_mut_ptr(), dist);
+            for k in 0..4 {
+                let idx = j + k;
+                if idx == i || idx >= xs.len() {
+                    continue;
+                }
+                let d = out[k];
+                if d < best[0] {
+                    best[2] = best[1];
+                    best[1] = best[0];
+                    best[0] = d;
+                } else if d < best[1] {
+                    best[2] = best[1];
+                    best[1] = d;
+                } else if d < best[2] {
+                    best[2] = d;
+                }
+            }
+            j += 4;
+        }
+        for j in j..xs.len() {
+            if j == i {
+                continue;
+            }
+            let dx = xs[j] - xi;
+            let dy = ys[j] - yi;
+            let dz = zs[j] - zi;
+            let d = dx * dx + dy * dy + dz * dz;
+            if d < best[0] {
+                best[2] = best[1];
+                best[1] = best[0];
+                best[0] = d;
+            } else if d < best[1] {
+                best[2] = best[1];
+                best[1] = d;
+            } else if d < best[2] {
+                best[2] = d;
+            }
+        }
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        use core::arch::aarch64::*;
+        let xi_v = vdupq_n_f32(xi);
+        let yi_v = vdupq_n_f32(yi);
+        let zi_v = vdupq_n_f32(zi);
+        let mut j = 0;
+        while j + 4 <= xs.len() {
+            let xj = vld1q_f32(xs.as_ptr().add(j));
+            let yj = vld1q_f32(ys.as_ptr().add(j));
+            let zjv = vld1q_f32(zs.as_ptr().add(j));
+            let dx = vsubq_f32(xj, xi_v);
+            let dy = vsubq_f32(yj, yi_v);
+            let dz = vsubq_f32(zjv, zi_v);
+            let mut dist = vmulq_f32(dx, dx);
+            dist = vmlaq_f32(dist, dy, dy);
+            dist = vmlaq_f32(dist, dz, dz);
+            let mut out = [0f32; 4];
+            vst1q_f32(out.as_mut_ptr(), dist);
+            for k in 0..4 {
+                let idx = j + k;
+                if idx == i || idx >= xs.len() {
+                    continue;
+                }
+                let d = out[k];
+                if d < best[0] {
+                    best[2] = best[1];
+                    best[1] = best[0];
+                    best[0] = d;
+                } else if d < best[1] {
+                    best[2] = best[1];
+                    best[1] = d;
+                } else if d < best[2] {
+                    best[2] = d;
+                }
+            }
+            j += 4;
+        }
+        for j in j..xs.len() {
+            if j == i {
+                continue;
+            }
+            let dx = xs[j] - xi;
+            let dy = ys[j] - yi;
+            let dz = zs[j] - zi;
+            let d = dx * dx + dy * dy + dz * dz;
+            if d < best[0] {
+                best[2] = best[1];
+                best[1] = best[0];
+                best[0] = d;
+            } else if d < best[1] {
+                best[2] = best[1];
+                best[1] = d;
+            } else if d < best[2] {
+                best[2] = d;
+            }
+        }
+    }
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+    {
+        for (j, (&xj, (&yj, &zj))) in xs.iter().zip(ys.iter().zip(zs.iter())).enumerate() {
+            if j == i {
+                continue;
+            }
+            let dx = xj - xi;
+            let dy = yj - yi;
+            let dz = zj - zi;
+            let d = dx * dx + dy * dy + dz * dz;
+            if d < best[0] {
+                best[2] = best[1];
+                best[1] = best[0];
+                best[0] = d;
+            } else if d < best[1] {
+                best[2] = best[1];
+                best[1] = d;
+            } else if d < best[2] {
+                best[2] = d;
+            }
+        }
+    }
+
+    (best[0].sqrt() + best[1].sqrt() + best[2].sqrt()) / 3.0
+}

--- a/src/python.rs
+++ b/src/python.rs
@@ -1,0 +1,55 @@
+#![cfg(feature = "python")]
+use crate::{GpuContext, compute_knn};
+use numpy::{PyArray1, PyReadonlyArray1};
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
+
+fn map_err<E: std::fmt::Display>(err: E) -> PyErr {
+    PyRuntimeError::new_err(err.to_string())
+}
+
+#[pyclass]
+struct PyGpuContext {
+    ctx: GpuContext,
+}
+
+#[pymethods]
+impl PyGpuContext {
+    #[new]
+    fn new() -> PyResult<Self> {
+        let ctx = pollster::block_on(GpuContext::new()).map_err(map_err)?;
+        Ok(Self { ctx })
+    }
+
+    fn device_description(&self) -> String {
+        self.ctx.device_description()
+    }
+
+    fn compute_knn<'py>(
+        &self,
+        py: Python<'py>,
+        points: PyReadonlyArray1<'py, f32>,
+    ) -> PyResult<Bound<'py, PyArray1<f32>>> {
+        let points_vec = points.as_slice()?.to_vec();
+        let result = pollster::block_on(compute_knn(&self.ctx, &points_vec)).map_err(map_err)?;
+        Ok(PyArray1::from_vec(py, result.distances))
+    }
+}
+
+#[pyfunction]
+fn compute_knn_blocking<'py>(
+    py: Python<'py>,
+    points: PyReadonlyArray1<'py, f32>,
+) -> PyResult<Bound<'py, PyArray1<f32>>> {
+    let ctx = pollster::block_on(GpuContext::new()).map_err(map_err)?;
+    let points_vec = points.as_slice()?.to_vec();
+    let result = pollster::block_on(compute_knn(&ctx, &points_vec)).map_err(map_err)?;
+    Ok(PyArray1::from_vec(py, result.distances))
+}
+
+#[pymodule]
+fn simple_knn_wgpu<'py>(_py: Python<'py>, m: &Bound<'py, PyModule>) -> PyResult<()> {
+    m.add_class::<PyGpuContext>()?;
+    m.add_function(wrap_pyfunction!(compute_knn_blocking, m)?)?;
+    Ok(())
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,65 +1,57 @@
 //! Integration tests for simple-knn-wgpu.
-//! 
+//!
 //! These tests verify that the GPU implementation produces correct results
 //! for various point cloud configurations.
 
-use simple_knn_wgpu::{compute_knn, GpuContext, KnnConfig};
 use approx::assert_relative_eq;
+use simple_knn_wgpu::{GpuContext, KnnConfig, compute_knn_auto, compute_knn_cpu};
 
 #[tokio::test]
 async fn test_simple_cube() {
-    let gpu = GpuContext::new().await.expect("Failed to initialize GPU");
-    
     // 8 points forming a unit cube
     let points = vec![
-        0.0, 0.0, 0.0,  // 0
-        1.0, 0.0, 0.0,  // 1
-        0.0, 1.0, 0.0,  // 2
-        1.0, 1.0, 0.0,  // 3
-        0.0, 0.0, 1.0,  // 4
-        1.0, 0.0, 1.0,  // 5
-        0.0, 1.0, 1.0,  // 6
-        1.0, 1.0, 1.0,  // 7
+        0.0, 0.0, 0.0, // 0
+        1.0, 0.0, 0.0, // 1
+        0.0, 1.0, 0.0, // 2
+        1.0, 1.0, 0.0, // 3
+        0.0, 0.0, 1.0, // 4
+        1.0, 0.0, 1.0, // 5
+        0.0, 1.0, 1.0, // 6
+        1.0, 1.0, 1.0, // 7
     ];
-    
-    let result = compute_knn(&gpu, &points).await.unwrap();
-    
+
+    let result = compute_knn_auto(&points).await.unwrap();
+
     assert_eq!(result.distances.len(), 8);
-    
+
     // Each corner of a unit cube has 3 neighbors at distances:
     // - 3 edge neighbors at distance 1.0
     // So mean distance should be 1.0
     for (_i, &dist) in result.distances.iter().enumerate() {
-        assert_relative_eq!(
-            dist, 
-            1.0, 
-            epsilon = 0.001
-        );
+        assert_relative_eq!(dist, 1.0, epsilon = 0.001);
     }
 }
 
 #[tokio::test]
 async fn test_line_of_points() {
-    let gpu = GpuContext::new().await.expect("Failed to initialize GPU");
-    
     // Points along a line with unit spacing
     let points = vec![
-        0.0, 0.0, 0.0,  // 0
-        1.0, 0.0, 0.0,  // 1
-        2.0, 0.0, 0.0,  // 2
-        3.0, 0.0, 0.0,  // 3
-        4.0, 0.0, 0.0,  // 4
+        0.0, 0.0, 0.0, // 0
+        1.0, 0.0, 0.0, // 1
+        2.0, 0.0, 0.0, // 2
+        3.0, 0.0, 0.0, // 3
+        4.0, 0.0, 0.0, // 4
     ];
-    
-    let result = compute_knn(&gpu, &points).await.unwrap();
-    
+
+    let result = compute_knn_auto(&points).await.unwrap();
+
     assert_eq!(result.distances.len(), 5);
-    
+
     // End points have neighbors at distances 1, 2, 3
     // Mean = (1 + 2 + 3) / 3 = 2.0
     assert_relative_eq!(result.distances[0], 2.0, epsilon = 0.001);
     assert_relative_eq!(result.distances[4], 2.0, epsilon = 0.001);
-    
+
     // Middle points have closer neighbors
     // Point 2 has neighbors at distances 1, 1, 2
     // Mean = (1 + 1 + 2) / 3 = 1.333...
@@ -68,11 +60,9 @@ async fn test_line_of_points() {
 
 #[tokio::test]
 async fn test_single_cluster() {
-    let gpu = GpuContext::new().await.expect("Failed to initialize GPU");
-    
     // Dense cluster at origin with one outlier
     let mut points = Vec::new();
-    
+
     // 10 points clustered near origin
     for i in 0..10 {
         let angle = (i as f32) * std::f32::consts::TAU / 10.0;
@@ -80,31 +70,36 @@ async fn test_single_cluster() {
         points.push(angle.sin() * 0.1);
         points.push(0.0);
     }
-    
+
     // One outlier far away
     points.push(10.0);
     points.push(0.0);
     points.push(0.0);
-    
-    let result = compute_knn(&gpu, &points).await.unwrap();
-    
+
+    let result = compute_knn_auto(&points).await.unwrap();
+
     assert_eq!(result.distances.len(), 11);
-    
+
     // Points in the cluster should have small distances
     for i in 0..10 {
-        assert!(result.distances[i] < 0.3, 
-            "Clustered point {} has too large distance: {}", i, result.distances[i]);
+        assert!(
+            result.distances[i] < 0.3,
+            "Clustered point {} has too large distance: {}",
+            i,
+            result.distances[i]
+        );
     }
-    
+
     // The outlier should have much larger distance
-    assert!(result.distances[10] > 5.0,
-        "Outlier has too small distance: {}", result.distances[10]);
+    assert!(
+        result.distances[10] > 5.0,
+        "Outlier has too small distance: {}",
+        result.distances[10]
+    );
 }
 
 #[tokio::test]
 async fn test_custom_config() {
-    let gpu = GpuContext::new().await.expect("Failed to initialize GPU");
-    
     // Test with custom configuration
     let config = KnnConfig {
         k: 3,
@@ -112,20 +107,20 @@ async fn test_custom_config() {
         max_points: 1000,
         max_workgroup_size: 256,
     };
-    
-    let points = vec![
-        0.0, 0.0, 0.0,
-        1.0, 0.0, 0.0,
-        0.0, 1.0, 0.0,
-        1.0, 1.0, 0.0,
-    ];
-    
-    let result = simple_knn_wgpu::compute_knn_with_config(&gpu, config, &points)
-        .await
-        .unwrap();
-    
+
+    let points = vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0];
+
+    let gpu = GpuContext::new().await.ok();
+    let result = if let Some(gpu) = gpu {
+        simple_knn_wgpu::compute_knn_with_config(&gpu, config, &points)
+            .await
+            .unwrap()
+    } else {
+        compute_knn_cpu(&points).unwrap()
+    };
+
     assert_eq!(result.distances.len(), 4);
-    
+
     // Verify computation time is recorded
     assert!(result.compute_time_ms.is_some());
     assert!(result.compute_time_ms.unwrap() >= 0.0);
@@ -133,40 +128,31 @@ async fn test_custom_config() {
 
 #[tokio::test]
 async fn test_empty_input() {
-    let gpu = GpuContext::new().await.expect("Failed to initialize GPU");
-    
     let points = vec![];
-    
-    let result = compute_knn(&gpu, &points).await;
-    
+
+    let result = compute_knn_auto(&points).await;
+
     // Should return an error for empty input
     assert!(result.is_err());
 }
 
-#[tokio::test] 
+#[tokio::test]
 async fn test_invalid_input() {
-    let gpu = GpuContext::new().await.expect("Failed to initialize GPU");
-    
     // Not a multiple of 3
     let points = vec![1.0, 2.0];
-    
-    let result = compute_knn(&gpu, &points).await;
-    
+
+    let result = compute_knn_auto(&points).await;
+
     // Should return an error for invalid input shape
     assert!(result.is_err());
 }
 
 #[tokio::test]
 async fn test_nan_handling() {
-    let gpu = GpuContext::new().await.expect("Failed to initialize GPU");
-    
-    let points = vec![
-        0.0, 0.0, 0.0,
-        f32::NAN, 0.0, 0.0,
-    ];
-    
-    let result = compute_knn(&gpu, &points).await;
-    
+    let points = vec![0.0, 0.0, 0.0, f32::NAN, 0.0, 0.0];
+
+    let result = compute_knn_auto(&points).await;
+
     // Should return an error for NaN values
     assert!(result.is_err());
-} 
+}


### PR DESCRIPTION
## Summary
- implement CPU fallback using SIMD and Rayon
- expose `compute_knn_cpu` and `compute_knn_auto`
- update tests to use the automatic CPU/GPU selection
- expand SIMD implementation to aarch64 NEON

## Testing
- `cargo test --no-default-features`
- `cargo build --no-default-features --features python`
- `cargo fmt --all -- --check`


------
https://chatgpt.com/codex/tasks/task_e_6889014ffb008326ab7ad70f2dc5757a