### PR TITLE
Optimize GPU radix sort

### DIFF
--- a/src/shaders.rs
+++ b/src/shaders.rs
@@ -118,8 +118,11 @@ mod tests {
         assert!(validate_shader_entry_points(sources.knn, &["compute_knn"]).is_ok());
 
         assert!(
-            validate_shader_entry_points(sources.radix, &["radix_count", "radix_reorder"]).is_ok()
+            validate_shader_entry_points(
+                sources.radix,
+                &["radix_count", "radix_prefix", "radix_reorder"]
+            )
+            .is_ok()
         );
     }
 }
-

--- a/src/shaders/sort.wgsl
+++ b/src/shaders/sort.wgsl
@@ -1,12 +1,14 @@
 // Radix Sort Shader
 //
 // Implements a simple GPU radix sort for 32-bit keys.
-// The algorithm performs one pass per bit using atomic counters
-// and two compute stages (count and reorder).
+// This version processes 4 bits per pass (radix 16) to reduce
+// the number of required compute dispatches compared to the
+// original bit-by-bit implementation. Each pass consists of
+// three stages: counting, prefix sum, and reorder.
 
 struct Params {
     num: u32,
-    bit: u32,
+    shift: u32,
 };
 
 @group(0) @binding(0)
@@ -14,7 +16,8 @@ var<storage, read> in_keys: array<u32>;
 @group(0) @binding(1)
 var<storage, read_write> prefix: array<u32>;
 @group(0) @binding(2)
-var<storage, read_write> counts: array<atomic<u32>, 2>;
+// One counter per radix bucket (16 buckets for 4 bits)
+var<storage, read_write> counts: array<atomic<u32>, 16>;
 @group(0) @binding(3)
 var<uniform> params: Params;
 
@@ -24,12 +27,25 @@ fn radix_count(@builtin(global_invocation_id) gid: vec3<u32>) {
     if (idx >= params.num) { return; }
 
     let key = in_keys[idx];
-    let bit = (key >> params.bit) & 1u;
+    let bin = (key >> params.shift) & 0xFu;
+    prefix[idx] = atomicAdd(&counts[bin], 1u);
+}
 
-    if (bit == 0u) {
-        prefix[idx] = atomicAdd(&counts[0], 1u);
-    } else {
-        prefix[idx] = atomicAdd(&counts[1], 1u);
+@group(0) @binding(0)
+// Atomic counts from the first pass
+var<storage, read_write> p_counts: array<atomic<u32>, 16>;
+@group(0) @binding(1)
+// Output prefix offsets per bucket
+var<storage, read_write> p_offsets: array<u32>;
+
+// Computes exclusive prefix sums of the counts buffer.
+@compute @workgroup_size(1)
+fn radix_prefix() {
+    var sum: u32 = 0u;
+    for (var i = 0u; i < 16u; i = i + 1u) {
+        let c = atomicLoad(&p_counts[i]);
+        p_offsets[i] = sum;
+        sum = sum + c;
     }
 }
 
@@ -41,7 +57,7 @@ var<storage, read> r_in_indices: array<u32>;
 var<storage, read> r_prefix: array<u32>;
 @group(0) @binding(3)
 // Atomic variables require read_write access even if only read
-var<storage, read_write> r_counts: array<atomic<u32>, 2>;
+var<storage, read> r_offsets: array<u32>;
 @group(0) @binding(4)
 var<storage, read_write> out_keys: array<u32>;
 @group(0) @binding(5)
@@ -55,14 +71,9 @@ fn radix_reorder(@builtin(global_invocation_id) gid: vec3<u32>) {
     if (idx >= r_params.num) { return; }
 
     let key = r_in_keys[idx];
-    let bit = (key >> r_params.bit) & 1u;
+    let bin = (key >> r_params.shift) & 0xFu;
     let p = r_prefix[idx];
-    let zeros = atomicLoad(&r_counts[0]);
-
-    var dst = p;
-    if (bit == 1u) {
-        dst = zeros + p;
-    }
+    let dst = r_offsets[bin] + p;
 
     out_keys[dst] = key;
     out_indices[dst] = r_in_indices[idx];


### PR DESCRIPTION
## Summary
- add radix prefix compute shader and handle 4-bit sorting per pass
- wire new radix_prefix pipeline into compute setup
- update radix sort logic to use prefix stage for fewer passes

## Testing
- `cargo test --workspace` *(fails: No suitable GPU adapter found)*

------
https://chatgpt.com/codex/tasks/task_e_6889db6ec04c8326b58ca454268b2380