### PR TITLE
Use push constants for radix sort

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -1,5 +1,5 @@
 //! GPU device management and initialization.
-//! 
+//!
 //! This module handles the creation and configuration of wgpu devices,
 //! ensuring we select appropriate hardware and configure it optimally
 //! for our KNN compute workloads.
@@ -28,23 +28,23 @@ pub struct GpuContext {
 
 impl GpuContext {
     /// Creates a new GPU context with the best available adapter.
-    /// 
+    ///
     /// This function will:
     /// 1. Enumerate all available adapters
     /// 2. Select the most powerful one (preferring discrete GPUs)
     /// 3. Create a device with appropriate limits
-    /// 
+    ///
     /// # Errors
     /// Returns an error if no suitable GPU adapter is found or device creation fails.
     pub async fn new() -> Result<Self> {
         let instance = create_instance();
         let adapter = select_best_adapter(&instance).await?;
-        
+
         Self::from_adapter(adapter).await
     }
-    
+
     /// Creates a GPU context from a specific adapter.
-    /// 
+    ///
     /// This is useful when you want to control adapter selection manually.
     pub async fn from_adapter(adapter: wgpu::Adapter) -> Result<Self> {
         let adapter_info = adapter.get_info();
@@ -52,14 +52,15 @@ impl GpuContext {
             "Selected GPU adapter: {} ({:?})",
             adapter_info.name, adapter_info.device_type
         );
-        
-        // Request device with specific features we need
-        let required_features = wgpu::Features::empty();
+
+        // Request device with features we need
+        // Enable push constants for efficient radix sort parameters
+        let required_features = wgpu::Features::PUSH_CONSTANTS;
         let required_limits = wgpu::Limits {
             max_bind_groups: 4,
             max_storage_buffer_binding_size: 128 * 1024 * 1024, // 128MB (more conservative)
-            max_buffer_size: 512 * 1024 * 1024, // 512MB (more conservative)
-            max_compute_workgroup_storage_size: 32 * 1024, // 32KB
+            max_buffer_size: 512 * 1024 * 1024,                 // 512MB (more conservative)
+            max_compute_workgroup_storage_size: 32 * 1024,      // 32KB
             max_compute_invocations_per_workgroup: 1024,
             max_compute_workgroup_size_x: 1024,
             max_compute_workgroup_size_y: 1024,
@@ -67,26 +68,24 @@ impl GpuContext {
             max_compute_workgroups_per_dimension: 65535,
             ..Default::default()
         };
-        
+
         let (device, queue) = adapter
-            .request_device(
-                &wgpu::DeviceDescriptor {
-                    label: Some("KNN Compute Device"),
-                    required_features,
-                    required_limits: required_limits.clone(),
-                    memory_hints: wgpu::MemoryHints::default(),
-                    trace: Default::default(),
-                },
-            )
+            .request_device(&wgpu::DeviceDescriptor {
+                label: Some("KNN Compute Device"),
+                required_features,
+                required_limits: required_limits.clone(),
+                memory_hints: wgpu::MemoryHints::default(),
+                trace: Default::default(),
+            })
             .await
             .map_err(|e| KnnError::GpuInitError(format!("Failed to create device: {}", e)))?;
-        
+
         let limits = device.limits();
         let features = device.features();
-        
+
         debug!("Device limits: {:?}", limits);
         debug!("Device features: {:?}", features);
-        
+
         Ok(Self {
             device: Arc::new(device),
             queue: Arc::new(queue),
@@ -95,9 +94,9 @@ impl GpuContext {
             features,
         })
     }
-    
+
     /// Creates a KNN configuration optimized for this device.
-    /// 
+    ///
     /// The configuration will respect device limits and choose appropriate
     /// workgroup sizes for optimal performance.
     pub fn create_optimal_config(&self) -> KnnConfig {
@@ -112,13 +111,13 @@ impl GpuContext {
         } else {
             128
         };
-        
+
         // Calculate maximum points based on available memory
         // We need roughly 40 bytes per point (point data + morton + indices + distances)
         let max_buffer_size = self.limits.max_buffer_size as usize;
         let bytes_per_point = 40;
         let max_points = (max_buffer_size / bytes_per_point).min(100_000_000) as u32;
-        
+
         KnnConfig {
             k: 3,
             box_size,
@@ -126,18 +125,18 @@ impl GpuContext {
             max_workgroup_size: self.limits.max_compute_invocations_per_workgroup,
         }
     }
-    
+
     /// Checks if the device supports the given configuration.
     pub fn supports_config(&self, config: &KnnConfig) -> Result<()> {
         config.validate().map_err(|e| KnnError::InvalidInput(e))?;
-        
+
         if config.box_size > self.limits.max_compute_invocations_per_workgroup {
             return Err(KnnError::NotSupported(format!(
                 "Box size {} exceeds device limit of {}",
                 config.box_size, self.limits.max_compute_invocations_per_workgroup
             )));
         }
-        
+
         // Check memory requirements
         let bytes_per_point = 40;
         let required_memory = config.max_points as usize * bytes_per_point;
@@ -147,17 +146,15 @@ impl GpuContext {
                 required_memory, self.limits.max_buffer_size
             )));
         }
-        
+
         Ok(())
     }
-    
+
     /// Gets a human-readable description of the GPU device.
     pub fn device_description(&self) -> String {
         format!(
             "{} ({:?}, driver: {})",
-            self.adapter_info.name,
-            self.adapter_info.device_type,
-            self.adapter_info.driver
+            self.adapter_info.name, self.adapter_info.device_type, self.adapter_info.driver
         )
     }
 }
@@ -180,14 +177,14 @@ async fn select_best_adapter(instance: &wgpu::Instance) -> Result<wgpu::Adapter>
             compatible_surface: None,
         })
         .await;
-    
+
     if let Ok(adapter) = adapter {
         let info = adapter.get_info();
         if matches!(info.device_type, wgpu::DeviceType::DiscreteGpu) {
             return Ok(adapter);
         }
     }
-    
+
     // If no discrete GPU, try any available adapter
     let adapter = instance
         .enumerate_adapters(wgpu::Backends::all())
@@ -203,16 +200,14 @@ async fn select_best_adapter(instance: &wgpu::Instance) -> Result<wgpu::Adapter>
                 wgpu::DeviceType::Other => 1,
             }
         });
-    
-    adapter.ok_or_else(|| {
-        KnnError::GpuInitError("No suitable GPU adapter found".to_string())
-    })
+
+    adapter.ok_or_else(|| KnnError::GpuInitError("No suitable GPU adapter found".to_string()))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[test]
     fn test_config_validation() {
         let config = KnnConfig {
@@ -221,20 +216,20 @@ mod tests {
             max_points: 1_000_000,
             max_workgroup_size: 1024,
         };
-        
+
         assert!(config.validate().is_ok());
-        
+
         // Test invalid configurations
         let invalid_config = KnnConfig {
             k: 0,
             ..config.clone()
         };
         assert!(invalid_config.validate().is_err());
-        
+
         let invalid_config = KnnConfig {
             box_size: 1023, // Not power of 2
             ..config
         };
         assert!(invalid_config.validate().is_err());
     }
-} 
+}

--- a/src/knn.rs
+++ b/src/knn.rs
@@ -423,10 +423,13 @@ impl KnnCompute {
         });
         let params = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("Radix Params"),
-            size: 256,
+            size: 4,
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
+        self.context
+            .queue
+            .write_buffer(&params, 0, bytemuck::bytes_of(&num_points));
 
         let workgroups = num_points.div_ceil(256);
         let mut src_keys = &buffers.morton;
@@ -435,13 +438,12 @@ impl KnnCompute {
         let mut dst_indices = &temp_indices;
 
         for bit in 0..30u32 {
+            // Reset counters for this bit
             self.context
                 .queue
                 .write_buffer(&counts, 0, bytemuck::bytes_of(&[0u32, 0u32]));
-            self.context
-                .queue
-                .write_buffer(&params, 0, bytemuck::bytes_of(&[num_points, bit]));
 
+            // Bind group for the counting pass
             let bg1 = device.create_bind_group(&wgpu::BindGroupDescriptor {
                 label: Some("Radix Count BG"),
                 layout: &self.pipelines.radix_count.get_bind_group_layout(0),
@@ -450,10 +452,6 @@ impl KnnCompute {
                         binding: 0,
                         resource: src_keys.as_entire_binding(),
                     },
-                    // wgpu::BindGroupEntry {
-                    //     binding: 1,
-                    //     resource: src_indices.as_entire_binding(),
-                    // },
                     wgpu::BindGroupEntry {
                         binding: 1,
                         resource: prefix.as_entire_binding(),
@@ -469,22 +467,7 @@ impl KnnCompute {
                 ],
             });
 
-            let mut encoder =
-                device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
-            {
-                let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
-                    label: Some("Radix Count Pass"),
-                    timestamp_writes: None,
-                });
-                pass.set_pipeline(&self.pipelines.radix_count);
-                pass.set_bind_group(0, &bg1, &[]);
-                pass.dispatch_workgroups(workgroups, 1, 1);
-            }
-            self.context.queue.submit(Some(encoder.finish()));
-
-            self.context
-                .queue
-                .write_buffer(&params, 0, bytemuck::bytes_of(&[num_points, bit]));
+            // Bind group for the reorder pass
             let bg2 = device.create_bind_group(&wgpu::BindGroupDescriptor {
                 label: Some("Radix Reorder BG"),
                 layout: &self.pipelines.radix_reorder.get_bind_group_layout(0),
@@ -520,8 +503,19 @@ impl KnnCompute {
                 ],
             });
 
+            // Use a single command encoder for both passes to reduce submission overhead
             let mut encoder =
                 device.create_command_encoder(&wgpu::CommandEncoderDescriptor::default());
+            {
+                let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                    label: Some("Radix Count Pass"),
+                    timestamp_writes: None,
+                });
+                pass.set_pipeline(&self.pipelines.radix_count);
+                pass.set_bind_group(0, &bg1, &[]);
+                pass.set_push_constants(0, bytemuck::bytes_of(&bit));
+                pass.dispatch_workgroups(workgroups, 1, 1);
+            }
             {
                 let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
                     label: Some("Radix Reorder Pass"),
@@ -529,6 +523,7 @@ impl KnnCompute {
                 });
                 pass.set_pipeline(&self.pipelines.radix_reorder);
                 pass.set_bind_group(0, &bg2, &[]);
+                pass.set_push_constants(0, bytemuck::bytes_of(&bit));
                 pass.dispatch_workgroups(workgroups, 1, 1);
             }
             self.context.queue.submit(Some(encoder.finish()));

--- a/src/shaders/sort.wgsl
+++ b/src/shaders/sort.wgsl
@@ -6,8 +6,14 @@
 
 struct Params {
     num: u32,
+};
+
+@push_constant
+struct Push {
     bit: u32,
 };
+
+var<push_constant> pc: Push;
 
 @group(0) @binding(0)
 var<storage, read> in_keys: array<u32>;
@@ -24,7 +30,7 @@ fn radix_count(@builtin(global_invocation_id) gid: vec3<u32>) {
     if (idx >= params.num) { return; }
 
     let key = in_keys[idx];
-    let bit = (key >> params.bit) & 1u;
+    let bit = (key >> pc.bit) & 1u;
 
     if (bit == 0u) {
         prefix[idx] = atomicAdd(&counts[0], 1u);
@@ -55,7 +61,7 @@ fn radix_reorder(@builtin(global_invocation_id) gid: vec3<u32>) {
     if (idx >= r_params.num) { return; }
 
     let key = r_in_keys[idx];
-    let bit = (key >> r_params.bit) & 1u;
+    let bit = (key >> pc.bit) & 1u;
     let p = r_prefix[idx];
     let zeros = atomicLoad(&r_counts[0]);
 


### PR DESCRIPTION
## Summary
- enable `PUSH_CONSTANTS` device feature
- update sort shader and host code to pass radix bit via push constants
- reduce buffer writes during radix sort

## Testing
- `cargo test --all --no-fail-fast` *(fails: No suitable GPU adapter found)*

------
https://chatgpt.com/codex/tasks/task_e_6889db6ec04c8326b58ca454268b2380